### PR TITLE
Dialog fixes

### DIFF
--- a/src/psip_dialog.erl
+++ b/src/psip_dialog.erl
@@ -329,8 +329,13 @@ handle_info({'DOWN', Ref, process, Pid, _}, #state{owner_mon = Ref, need_cleanup
                 notify -> error(not_supported_yet)
             end
     end;
-handle_info({'DOWN', _Ref, process, _Pid, _}, #state{owner_mon = _} = State) ->
+handle_info({'DOWN', _Ref, process, Pid, _}, #state{owner_mon = _} = State) ->
+    log_debug(State, "owner of dialog is died: ~p; start stop_timeout", [Pid]),
+    erlang:send_after(timer:seconds(32), self(), stop_timeout),
     {noreply, State};
+handle_info(stop_timeout, State) ->
+    log_debug(State, "stop_timeout; stop dialog", []),
+    {stop, normal, State};
 handle_info(Msg, State) ->
     log_error(State, "unexpected info: ~0p", [Msg]),
     {noreply, State}.

--- a/src/psip_dialog.erl
+++ b/src/psip_dialog.erl
@@ -304,7 +304,7 @@ handle_info({'DOWN', Ref, process, Pid, _}, #state{owner_mon = Ref, need_cleanup
     case ersip_dialog:is_early(State#state.dialog) of
         true ->
             log_warning(State, "owner of early dialog is died: ~p; stop dialog", [Pid]),
-            {noreply, State};
+            {stop, normal, State};
         false ->
             log_warning(State, "owner of confirmed dialog is died: ~p; destroy dialog gracefully", [Pid]),
             case State#state.dialog_type of


### PR DESCRIPTION
- stop early dialog if owner died
- new function uas_cancel. if uas (A party) cancel then dialog will finish with warning when owner died, because 487 which sent after cancel is hop-by-hop and has different to-tag. so it is good to have a way to stop dialog without cancel  
- if one party A/B send BYE psip_dialog set need_cleanup = false and dialog process will not stop after owner died. But other party may disconnect completely and does not send 200 BYE, as a result dialog process will remain running and consume memory. so I suggest to run timeout after owner died and stop process even if we do not receive 200 BYE